### PR TITLE
Update cloning instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,9 +4,9 @@ OmniGroup
 Checking out the source
 -----------------------
 
-git clone git://github.com/omnigroup/OmniGroup
-git submodule init
-git submodule update
+    git clone git://github.com/omnigroup/OmniGroup
+    git submodule init
+    git submodule update
 
 Configuring Xcode 4
 -------------------


### PR DESCRIPTION
The instructions were showing up all on one line on github. This fixes it and makes the clone shell commands match the other shell instructions below.
