### PR TITLE
TextEditor sample: Allow scrolling when viewUsedSize > contentSize

### DIFF
--- a/Frameworks/OmniUI/iPad/Examples/TextEditor/Classes/TextScrollView.m
+++ b/Frameworks/OmniUI/iPad/Examples/TextEditor/Classes/TextScrollView.m
@@ -31,14 +31,24 @@ RCS_ID("$Id$");
         // First make sure the text is the right width so that it can calculate the right used height
         CGRect textFrame = _textView.frame;
         if (textFrame.size.width != bounds.size.width) {
-            _textView.frame = CGRectMake(0, 0, bounds.size.width, textFrame.size.height);
+            textFrame.size.width = bounds.size.width;
         }
         
         // Then ensure the height is large enough to span the text (or our height).
         CGSize usedSize = _textView.viewUsedSize;
         CGFloat height = MAX(bounds.size.height, usedSize.height);
         if (height != textFrame.size.height) {
-            _textView.frame = CGRectMake(0, 0, bounds.size.width, height);
+           textFrame.size.height = height;
+        }
+        
+        // Adjust the textView frame only if needed
+        if (!CGRectEqualToRect(_textView.frame, textFrame)) {
+            _textView.frame = textFrame;
+        }
+
+        // Adjust the contentSize so we can scroll
+        if (!CGSizeEqualToSize(self.contentSize, textFrame.size)) {
+            self.contentSize = textFrame.size;
         }
     }
     


### PR DESCRIPTION
Minor tweak to the TextEditor sample to adjust the `contentSize` to be the same as `_textView.viewUsedSize` so the user can scroll through the text.
