### PR TITLE
Adjust bitcode settings

### DIFF
--- a/Configurations/Omni-Global-Common.xcconfig
+++ b/Configurations/Omni-Global-Common.xcconfig
@@ -24,10 +24,6 @@ OTHER_SWIFT_FLAGS = $(OMNI_STORE_SWIFT_FLAGS) $(OMNI_GLOBAL_COMMON_SWIFT_FLAGS) 
 STRIP_INSTALLED_PRODUCT = NO
 COPY_PHASE_STRIP = NO
 
-// Enable Bitcode
-ENABLE_BITCODE = YES
-STRIP_BITCODE_FROM_COPIED_FILES = NO
-
 // Keep shared precompiled headers in our build area so we can clean them up. Without this, Xcode will put them in its own place and won't purge them reliably.
 SHARED_PRECOMPS_DIR = $(CONFIGURATION_BUILD_DIR)/SharedPrecompiledHeaders
 

--- a/Configurations/Target-Mac-Common.xcconfig
+++ b/Configurations/Target-Mac-Common.xcconfig
@@ -13,6 +13,9 @@ BZ2_LDFLAGS = -lbz2
 SDKROOT = macosx
 MACOSX_DEPLOYMENT_TARGET = 10.10
 
+// Disable Bitcode
+ENABLE_BITCODE = NO
+
 // Don't install every single thing we build. Lots of bundles and tools, in particular, are included as resources of frameworks and apps.
 SKIP_INSTALL = YES
 

--- a/Configurations/Target-Touch-Common.xcconfig
+++ b/Configurations/Target-Touch-Common.xcconfig
@@ -18,6 +18,10 @@ ENABLE_BITCODE = YES
 STRIP_BITCODE_FROM_COPIED_FILES = NO
 GCC_THUMB_SUPPORT = NO
 
+// Enable Bitcode
+ENABLE_BITCODE = YES
+STRIP_BITCODE_FROM_COPIED_FILES = NO
+
 // Don't install every single thing we build. Lots of bundles and tools, in particular, are included as resources of frameworks and apps.
 SKIP_INSTALL = YES
 

--- a/Configurations/Target-Watch-Common.xcconfig
+++ b/Configurations/Target-Watch-Common.xcconfig
@@ -19,6 +19,10 @@ ENABLE_BITCODE = YES
 STRIP_BITCODE_FROM_COPIED_FILES = NO
 GCC_THUMB_SUPPORT = NO
 
+// Enable Bitcode
+ENABLE_BITCODE = YES
+STRIP_BITCODE_FROM_COPIED_FILES = NO
+
 // Don't install every single thing we build. Lots of bundles and tools, in particular, are included as resources of frameworks and apps.
 SKIP_INSTALL = YES
 


### PR DESCRIPTION
For macosx platform bitcode is not supported.

With this patch the build on OS X 10.10+ with OS X SDK 10.11 on Xcode 7 is working again. 