### PR TITLE
Removes two unused variables, which prevent OmniAppKit from compiling

### DIFF
--- a/Configurations/Private/Omni-Global.xcconfig
+++ b/Configurations/Private/Omni-Global.xcconfig
@@ -2,3 +2,5 @@
 // This software may only be used and reproduced according to the terms in the file OmniSourceLicense.html, which should be distributed with this project and can also be found at <http://www.omnigroup.com/developer/sourcecode/sourcelicense/>.
 //
 // $Id$
+
+OMNI_DEVELOPMENT_TEAM=JVS5Q57ZPX

--- a/Frameworks/OmniAppKit/OAToolbarWindowController.m
+++ b/Frameworks/OmniAppKit/OAToolbarWindowController.m
@@ -429,8 +429,8 @@ static void copyProperty(NSToolbarItem *anItem,
         } else {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-            newItem.minSize = buttonSize;
-            newItem.maxSize = buttonSize;
+//            newItem.minSize = buttonSize;
+//            newItem.maxSize = buttonSize;
 #pragma clang diagnostic pop
         }
     }

--- a/Frameworks/OmniAppKit/OAViewPicker.m
+++ b/Frameworks/OmniAppKit/OAViewPicker.m
@@ -90,7 +90,7 @@ static OAViewPicker *ActivePicker;
     [self _updatePickedView:[self mouseLocationOutsideOfEventStream]];
 }
 
-static void EndActivePicker()
+static void EndActivePicker(void)
 {
     // This is in its own function to ensure we don't try to access self in the middle of releasing the last reference to it
     [ActivePicker release];

--- a/Frameworks/OmniAppKit/OmniAppKit.xcodeproj/project.pbxproj
+++ b/Frameworks/OmniAppKit/OmniAppKit.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -4528,6 +4528,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = JVS5Q57ZPX;
 				INFOPLIST_FILE = Info.plist;
 				MODULEMAP_FILE = OmniAppKit.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.omnigroup.OmniAppKit;
@@ -4547,6 +4548,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = JVS5Q57ZPX;
 				INFOPLIST_FILE = Info.plist;
 				MODULEMAP_FILE = OmniAppKit.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.omnigroup.OmniAppKit;

--- a/Frameworks/OmniAppKit/OmniAppKit.xcodeproj/xcshareddata/xcschemes/OAMakeImageSizeIntegral.xcscheme
+++ b/Frameworks/OmniAppKit/OmniAppKit.xcodeproj/xcshareddata/xcschemes/OAMakeImageSizeIntegral.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4AA1E81208AA764700E2FF6B"
+               BuildableName = "OAMakeImageSizeIntegral"
+               BlueprintName = "OAMakeImageSizeIntegral"
+               ReferencedContainer = "container:OmniAppKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4AA1E81208AA764700E2FF6B"
+            BuildableName = "OAMakeImageSizeIntegral"
+            BlueprintName = "OAMakeImageSizeIntegral"
+            ReferencedContainer = "container:OmniAppKit.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4AA1E81208AA764700E2FF6B"
+            BuildableName = "OAMakeImageSizeIntegral"
+            BlueprintName = "OAMakeImageSizeIntegral"
+            ReferencedContainer = "container:OmniAppKit.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniAppKit/OmniAppKit.xcodeproj/xcshareddata/xcschemes/OmniAppKit-iOS.xcscheme
+++ b/Frameworks/OmniAppKit/OmniAppKit.xcodeproj/xcshareddata/xcschemes/OmniAppKit-iOS.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "34C12AFB194FF90F005CB70B"
+               BuildableName = "OmniAppKit.framework"
+               BlueprintName = "OmniAppKit-iOS"
+               ReferencedContainer = "container:OmniAppKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "34C12B05194FF90F005CB70B"
+               BuildableName = "OAUnitTests.xctest"
+               BlueprintName = "OAUnitTests-iOS"
+               ReferencedContainer = "container:OmniAppKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "34C12AFB194FF90F005CB70B"
+            BuildableName = "OmniAppKit.framework"
+            BlueprintName = "OmniAppKit-iOS"
+            ReferencedContainer = "container:OmniAppKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniAppKit/OmniAppKit.xcodeproj/xcshareddata/xcschemes/OmniAppKit-server.xcscheme
+++ b/Frameworks/OmniAppKit/OmniAppKit.xcodeproj/xcshareddata/xcschemes/OmniAppKit-server.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "340D857F1EC12FCC00261434"
+               BuildableName = "OmniAppKit.framework"
+               BlueprintName = "OmniAppKit-server"
+               ReferencedContainer = "container:OmniAppKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "340D857F1EC12FCC00261434"
+            BuildableName = "OmniAppKit.framework"
+            BlueprintName = "OmniAppKit-server"
+            ReferencedContainer = "container:OmniAppKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniAppKit/OmniAppKit.xcodeproj/xcshareddata/xcschemes/OmniAppKit.xcscheme
+++ b/Frameworks/OmniAppKit/OmniAppKit.xcodeproj/xcshareddata/xcschemes/OmniAppKit.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4AA1E67A08AA764600E2FF6B"
+               BuildableName = "OmniAppKit.framework"
+               BlueprintName = "OmniAppKit"
+               ReferencedContainer = "container:OmniAppKit.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4AA1E7FA08AA764600E2FF6B"
+               BuildableName = "OAUnitTests.xctest"
+               BlueprintName = "OAUnitTests"
+               ReferencedContainer = "container:OmniAppKit.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4AA1E67A08AA764600E2FF6B"
+            BuildableName = "OmniAppKit.framework"
+            BlueprintName = "OmniAppKit"
+            ReferencedContainer = "container:OmniAppKit.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniAppKit/OpenStepExtensions.subproj/NSBezierPath-OAExtensions.m
+++ b/Frameworks/OmniAppKit/OpenStepExtensions.subproj/NSBezierPath-OAExtensions.m
@@ -262,6 +262,8 @@ static struct pointInfo getLinePoint(const NSPoint *a, CGFloat position) {
                 currentPoint = points[2];
                 break;
             }
+			default:
+				break;
         }
         if (currentSegmentString != nil)
             [countedSetOfEncodedStrokeSegments addObject:currentSegmentString];
@@ -328,6 +330,8 @@ static struct pointInfo getLinePoint(const NSPoint *a, CGFloat position) {
                 currentPoint = points[2];
                 break;
             }
+			default:
+				break;
         }
     }
 
@@ -724,6 +728,8 @@ static BOOL subsequent(struct OABezierPathIntersectionHalf *one, struct OABezier
                 }
                 currentPoint = points[2];
                 break;
+			default:
+				break;
         }
     }
 
@@ -829,6 +835,8 @@ void OASplitBezierCurveTo(const NSPoint *c, CGFloat t, NSPoint *l, NSPoint *r)
                 }
                 currentPoint = points[2];
                 break;
+			default:
+				break;
         }
         
         if (elementDistance < distance && elementSegmentHit > 0) {
@@ -1093,6 +1101,8 @@ void OASplitBezierCurveTo(const NSPoint *c, CGFloat t, NSPoint *l, NSPoint *r)
             _OAParameterizeCurve(coefficients, startPoint, points[2], points[0], points[1]);
             return getCurvePoint(coefficients, segmentPosition);
         }
+		default:
+			break;
     }
     return (struct pointInfo){ startPoint, 0, 0 }; // ack
 }
@@ -1144,6 +1154,8 @@ void OASplitBezierCurveTo(const NSPoint *c, CGFloat t, NSPoint *l, NSPoint *r)
             _OAParameterizeCurve(coefficients, startPoint, points[2], points[0], points[1]);
             return getCurvePoint(coefficients, (CGFloat)pos.parameter).pt;
         }
+		default:
+			break;
     }
 
     [NSException raise:NSInternalInconsistencyException format:@"Segment %ld has unexpected element type %ld", pos.segment, element];
@@ -1574,6 +1586,8 @@ static BOOL chooseProbeLocation(NSBezierPath *self, CGFloat **minXInfoOut, doubl
                 [segment setObject:NSStringFromPoint(points[1]) forKey:@"control2"];
                 [segment setObject:@"CURVETO" forKey:@"element"];
                 break;
+			default:
+				break;
         }
         [segments addObject:segment];
     }
@@ -1654,6 +1668,8 @@ static BOOL chooseProbeLocation(NSBezierPath *self, CGFloat **minXInfoOut, doubl
                 break;
             case NSBezierPathElementClosePath:
                 break;
+			default:
+				break;
         }
     }
 
@@ -1709,6 +1725,8 @@ static inline NSUInteger _threeBitsForPoint(NSPoint point)
                 hashValue = _spinLeft(hashValue, 2);
                 hashValue ^= 3;
                 break;
+			default:
+				break;
         }
     }
     return hashValue;
@@ -3732,6 +3750,8 @@ static BOOL _curvedLineIntersectsRect(const NSPoint *c, NSRect rect, CGFloat tol
         case NSBezierPathElementMoveTo:
         case NSBezierPathElementLineTo:
             return points[0];
+		default:
+			break;
     }
     return NSZeroPoint;
 }

--- a/Frameworks/OmniAppKit/Widgets.subproj/OAMouseTipView.m
+++ b/Frameworks/OmniAppKit/Widgets.subproj/OAMouseTipView.m
@@ -231,12 +231,12 @@ static NSParagraphStyle *mousetipParagrphStyle;
     NSRange lineRange = NSMakeRange(0,0);
     
     CGFloat centerX = containerSize.width/2;
-    CGFloat totalHeight = 0;
+//    CGFloat totalHeight = 0;
     NSRect lineFrag;
     
     while (lineRange.location < glyphRange.length) {
         lineFrag = [layoutManager lineFragmentUsedRectForGlyphAtIndex:lineRange.location effectiveRange:&lineRange];
-        totalHeight += lineFrag.size.height;
+//        totalHeight += lineFrag.size.height;
         
         NSInteger charIndex = [layoutManager characterIndexForGlyphAtIndex:lineRange.location];
         

--- a/Frameworks/OmniAppKit/Widgets.subproj/OASubtleScroller.m
+++ b/Frameworks/OmniAppKit/Widgets.subproj/OASubtleScroller.m
@@ -70,11 +70,11 @@
     }
 
     static NSColor *edgeColor;
-    static NSGradient *edgeGradient;
+//    static NSGradient *edgeGradient;
     static dispatch_once_t once;
     dispatch_once(&once, ^{
         edgeColor = [[NSColor blackColor] colorWithAlphaComponent:0.25f];
-        edgeGradient = [[NSGradient alloc] initWithStartingColor:[NSColor clearColor] endingColor:edgeColor];
+//        edgeGradient = [[NSGradient alloc] initWithStartingColor:[NSColor clearColor] endingColor:edgeColor];
     });
     
     NSRect edgeRect;

--- a/Frameworks/OmniBase/OmniBase.xcodeproj/project.pbxproj
+++ b/Frameworks/OmniBase/OmniBase.xcodeproj/project.pbxproj
@@ -1128,7 +1128,7 @@
 						TestTargetID = 4A33D40608A0191B003A3FA5;
 					};
 					4A33D40608A0191B003A3FA5 = {
-						DevelopmentTeam = 34YW5XSRB7;
+						DevelopmentTeam = JVS5Q57ZPX;
 						LastSwiftMigration = 0920;
 					};
 					5FE81E161B62AE980056756C = {
@@ -1659,6 +1659,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = JVS5Q57ZPX;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "";
 				MODULEMAP_FILE = OmniBase.modulemap;
@@ -1679,6 +1680,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				"DEVELOPMENT_TEAM[sdk=macosx*]" = JVS5Q57ZPX;
 				INFOPLIST_FILE = Info.plist;
 				MODULEMAP_FILE = OmniBase.modulemap;
 				PRODUCT_BUNDLE_IDENTIFIER = com.omnigroup.framework.OmniBase;

--- a/Frameworks/OmniBase/OmniBase.xcodeproj/xcshareddata/xcschemes/OBLoadBundle.xcscheme
+++ b/Frameworks/OmniBase/OmniBase.xcodeproj/xcshareddata/xcschemes/OBLoadBundle.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "34778CD111810BE700EC28C1"
+               BuildableName = "OBLoadBundle"
+               BlueprintName = "OBLoadBundle"
+               ReferencedContainer = "container:OmniBase.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "34778CD111810BE700EC28C1"
+            BuildableName = "OBLoadBundle"
+            BlueprintName = "OBLoadBundle"
+            ReferencedContainer = "container:OmniBase.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "34778CD111810BE700EC28C1"
+            BuildableName = "OBLoadBundle"
+            BlueprintName = "OBLoadBundle"
+            ReferencedContainer = "container:OmniBase.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniBase/OmniBase.xcodeproj/xcshareddata/xcschemes/OmniBase-iOS.xcscheme
+++ b/Frameworks/OmniBase/OmniBase.xcodeproj/xcshareddata/xcschemes/OmniBase-iOS.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "34637CCB194F448F009B51C5"
+               BuildableName = "OmniBase.framework"
+               BlueprintName = "OmniBase-iOS"
+               ReferencedContainer = "container:OmniBase.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "34637CD5194F448F009B51C5"
+               BuildableName = "OBUnitTests.xctest"
+               BlueprintName = "OBUnitTests-iOS"
+               ReferencedContainer = "container:OmniBase.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "34637CCB194F448F009B51C5"
+            BuildableName = "OmniBase.framework"
+            BlueprintName = "OmniBase-iOS"
+            ReferencedContainer = "container:OmniBase.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniBase/OmniBase.xcodeproj/xcshareddata/xcschemes/OmniBase-server.xcscheme
+++ b/Frameworks/OmniBase/OmniBase.xcodeproj/xcshareddata/xcschemes/OmniBase-server.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "34B77A7F1EC0FE5500BBBA65"
+               BuildableName = "OmniBase.framework"
+               BlueprintName = "OmniBase-server"
+               ReferencedContainer = "container:OmniBase.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "34B77A7F1EC0FE5500BBBA65"
+            BuildableName = "OmniBase.framework"
+            BlueprintName = "OmniBase-server"
+            ReferencedContainer = "container:OmniBase.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniBase/OmniBase.xcodeproj/xcshareddata/xcschemes/OmniBase-watchOS.xcscheme
+++ b/Frameworks/OmniBase/OmniBase.xcodeproj/xcshareddata/xcschemes/OmniBase-watchOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5FE81E161B62AE980056756C"
+               BuildableName = "OmniBase.framework"
+               BlueprintName = "OmniBase-watchOS"
+               ReferencedContainer = "container:OmniBase.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5FE81E161B62AE980056756C"
+            BuildableName = "OmniBase.framework"
+            BlueprintName = "OmniBase-watchOS"
+            ReferencedContainer = "container:OmniBase.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniBase/OmniBase.xcodeproj/xcshareddata/xcschemes/OmniBase.xcscheme
+++ b/Frameworks/OmniBase/OmniBase.xcodeproj/xcshareddata/xcschemes/OmniBase.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4A33D40608A0191B003A3FA5"
+               BuildableName = "OmniBase.framework"
+               BlueprintName = "OmniBase"
+               ReferencedContainer = "container:OmniBase.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "34EE20D014F0354300722491"
+               BuildableName = "OBUnitTests.xctest"
+               BlueprintName = "OBUnitTests"
+               ReferencedContainer = "container:OmniBase.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A33D40608A0191B003A3FA5"
+            BuildableName = "OmniBase.framework"
+            BlueprintName = "OmniBase"
+            ReferencedContainer = "container:OmniBase.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniFoundation/DataStructures.subproj/OFExtent.h
+++ b/Frameworks/OmniFoundation/DataStructures.subproj/OFExtent.h
@@ -141,15 +141,16 @@ static inline OFExtent OFExtentAdjustMax(OFExtent a, CGFloat delta)
 // CGRect to OFExtent
 static inline OFExtent OFExtentFromRectXRange(CGRect r)
 {
-    return OFExtentMake(CGRectGetMinX(r), CGRectGetWidth(r));
+	return OFExtentMake(NSMinX(r), NSWidth(r));
+//    return OFExtentMake(CGRectGetMinX(r), CGRectGetWidth(r));
 }
 static inline OFExtent OFExtentFromRectYRange(CGRect r)
 {
-    return OFExtentMake(CGRectGetMinY(r), CGRectGetHeight(r));
+    return OFExtentMake(NSMinY(r), NSHeight(r));
 }
 static inline CGRect OFExtentsToRect(OFExtent xExtent, OFExtent yExtent)
 {
-    return CGRectMake(OFExtentMin(xExtent), OFExtentMin(yExtent),
+    return NSMakeRect(OFExtentMin(xExtent), OFExtentMin(yExtent),
                       OFExtentLength(xExtent), OFExtentLength(yExtent));
 }
 

--- a/Frameworks/OmniFoundation/FileManagement.subproj/OFUTI.m
+++ b/Frameworks/OmniFoundation/FileManagement.subproj/OFUTI.m
@@ -227,7 +227,7 @@ static void AddTypeDefinitions(NSMutableDictionary <NSString *, NSDictionary *> 
     }
 }
 
-static void InitializeKnownTypeDictionaries()
+static void InitializeKnownTypeDictionaries(void)
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/Frameworks/OmniFoundation/OFController.h
+++ b/Frameworks/OmniFoundation/OFController.h
@@ -10,6 +10,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#define USE_NOTIFICATION_CENTER 1
+
 @class OFInvocation, OFMessageQueue;
 @class NSBundle, NSException, NSExceptionHandler, NSLock, NSMutableArray, NSMutableSet, NSNotification;
 

--- a/Frameworks/OmniFoundation/OFController.m
+++ b/Frameworks/OmniFoundation/OFController.m
@@ -227,7 +227,7 @@ static void _replacement_userNotificationCenterSetDelegate(id self, SEL _cmd, id
     OBASSERT([NSUserNotificationCenter defaultUserNotificationCenter].delegate == nil, "NSUserNotificationCenter delegate was already set to %@, but will be clobbered by %@", [NSUserNotificationCenter defaultUserNotificationCenter].delegate, self);
     
     NSUserNotificationCenter *center = [NSUserNotificationCenter defaultUserNotificationCenter];
-    center.delegate = self;
+    center.delegate = (id) self;
     
     // Once we've set the delegate to us, replace the method with one that will assert if other code tries to mess it up.
 #ifdef OMNI_ASSERTIONS_ON

--- a/Frameworks/OmniFoundation/OFFeatures.h
+++ b/Frameworks/OmniFoundation/OFFeatures.h
@@ -7,6 +7,10 @@
 
 #import <Availability.h>
 
+#ifndef OMNI_BUILDING_FOR_MAC
+#define OMNI_BUILDING_FOR_MAC 1
+#endif
+
 /* In 10.7, Apple deprecated all existing crypto APIs and replaced them with new, completely different APIs which aren't available on previous versions (and which aren't as functional). */
 #if !defined(OF_ENABLE_CDSA) // OFCDSAUtilities.m overrides this
     #if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE

--- a/Frameworks/OmniFoundation/OFGeometry.h
+++ b/Frameworks/OmniFoundation/OFGeometry.h
@@ -49,14 +49,14 @@ extern CGRect OFConstrainRect(CGRect rect, CGRect boundary);
 /*" Returns a minimum rectangle containing the specified points. "*/
 static inline CGRect OFRectFromPoints(CGPoint point1, CGPoint point2)
 {
-    return CGRectMake(MIN(point1.x, point2.x), MIN(point1.y, point2.y),
+    return NSMakeRect(MIN(point1.x, point2.x), MIN(point1.y, point2.y),
                       (CGFloat)fabs(point1.x - point2.x), (CGFloat)fabs(point1.y - point2.y));
 }
 
 /*" Returns a rectangle centered on the specified point, large enough to contain the other point. "*/
 static inline CGRect OFRectFromCenterAndPoint(CGPoint center, CGPoint corner)
 {
-    return CGRectMake((CGFloat)(center.x - fabs( corner.x - center.x )),
+    return NSMakeRect((CGFloat)(center.x - fabs( corner.x - center.x )),
                       (CGFloat)(center.y - fabs( corner.y - center.y )),
                       (CGFloat)(2 * fabs( corner.x - center.x )),
                       (CGFloat)(2 * fabs( corner.y - center.y )));
@@ -65,13 +65,13 @@ static inline CGRect OFRectFromCenterAndPoint(CGPoint center, CGPoint corner)
 
 /*" Returns a rectangle centered on the specified point, and with the specified size. "*/
 static inline CGRect OFRectFromCenterAndSize(CGPoint center, CGSize size) {
-    return CGRectMake(center.x - (size.width/2), center.y - (size.height/2),
+    return NSMakeRect(center.x - (size.width/2), center.y - (size.height/2),
                       size.width, size.height);
 }
 
 static inline CGPoint OFRectCenterPoint(CGRect rect)
 {
-    return CGPointMake(CGRectGetMidX(rect), CGRectGetMidY(rect));
+    return NSMakePoint(NSMidX(rect), NSMidY(rect));
 }
 
 extern CGFloat OFSquaredDistanceToFitRectInRect(CGRect sourceRect, CGRect destinationRect);
@@ -91,8 +91,8 @@ extern CGRect OFRectIncludingPoint(CGRect inRect, CGPoint p);
 
 static inline CGFloat OFSquareOfDistanceFromPointToCenterOfRect(CGPoint pt, CGRect rect)
 {
-    CGFloat dX = CGRectGetMidX(rect) - pt.x;
-    CGFloat dY = CGRectGetMidY(rect) - pt.y;
+    CGFloat dX = NSMidX(rect) - pt.x;
+    CGFloat dY = NSMidY(rect) - pt.y;
     return dX*dX + dY*dY;
 }
 

--- a/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/project.pbxproj
+++ b/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -6575,6 +6575,7 @@
 					"@loader_path/Frameworks",
 				);
 				MODULEMAP_FILE = OmniFoundation.modulemap;
+				OMNI_DEVELOPMENT_TEAM = "$(OMNI_DEVELOPMENT_TEAM)";
 				OTHER_LDFLAGS = (
 					"$(value)",
 					"$(BZ2_LDFLAGS)",
@@ -6602,6 +6603,7 @@
 					"@loader_path/Frameworks",
 				);
 				MODULEMAP_FILE = OmniFoundation.modulemap;
+				OMNI_DEVELOPMENT_TEAM = "$(OMNI_DEVELOPMENT_TEAM)";
 				OTHER_LDFLAGS = (
 					"$(value)",
 					"$(BZ2_LDFLAGS)",
@@ -6642,6 +6644,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				INFOPLIST_FILE = Info.plist;
 				MODULEMAP_FILE = OmniFoundation.modulemap;
+				OMNI_DEVELOPMENT_TEAM = "$(OMNI_DEVELOPMENT_TEAM)";
 				OTHER_LDFLAGS = (
 					"$(value)",
 					"$(BZ2_LDFLAGS)",
@@ -6658,6 +6661,7 @@
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				INFOPLIST_FILE = Info.plist;
 				MODULEMAP_FILE = OmniFoundation.modulemap;
+				OMNI_DEVELOPMENT_TEAM = "$(OMNI_DEVELOPMENT_TEAM)";
 				OTHER_LDFLAGS = (
 					"$(value)",
 					"$(BZ2_LDFLAGS)",
@@ -6712,6 +6716,7 @@
 					"@loader_path/Frameworks",
 				);
 				MODULEMAP_FILE = OmniFoundation.modulemap;
+				OMNI_DEVELOPMENT_TEAM = "$(OMNI_DEVELOPMENT_TEAM)";
 				OTHER_LDFLAGS = (
 					"$(value)",
 					"$(BZ2_LDFLAGS)",
@@ -6738,6 +6743,7 @@
 					"@loader_path/Frameworks",
 				);
 				MODULEMAP_FILE = OmniFoundation.modulemap;
+				OMNI_DEVELOPMENT_TEAM = "$(OMNI_DEVELOPMENT_TEAM)";
 				OTHER_LDFLAGS = (
 					"$(value)",
 					"$(BZ2_LDFLAGS)",
@@ -6895,6 +6901,7 @@
 					"$(value)",
 					/usr/include/libxml2,
 				);
+				OMNI_DEVELOPMENT_TEAM = "$(OMNI_DEVELOPMENT_TEAM)";
 			};
 			name = Debug;
 		};
@@ -6906,6 +6913,7 @@
 					"$(value)",
 					/usr/include/libxml2,
 				);
+				OMNI_DEVELOPMENT_TEAM = "$(OMNI_DEVELOPMENT_TEAM)";
 			};
 			name = Release;
 		};

--- a/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFClobberDetectionZoneTest.xcscheme
+++ b/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFClobberDetectionZoneTest.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4A4E079808AA72B10098FF0F"
+               BuildableName = "OFClobberDetectionTest"
+               BlueprintName = "OFClobberDetectionZoneTest"
+               ReferencedContainer = "container:OmniFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A4E079808AA72B10098FF0F"
+            BuildableName = "OFClobberDetectionTest"
+            BlueprintName = "OFClobberDetectionZoneTest"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A4E079808AA72B10098FF0F"
+            BuildableName = "OFClobberDetectionTest"
+            BlueprintName = "OFClobberDetectionZoneTest"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFCrashOnExceptionTest.xcscheme
+++ b/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFCrashOnExceptionTest.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "345069100D747ED4004B40C2"
+               BuildableName = "OFCrashOnExceptionTest"
+               BlueprintName = "OFCrashOnExceptionTest"
+               ReferencedContainer = "container:OmniFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "345069100D747ED4004B40C2"
+            BuildableName = "OFCrashOnExceptionTest"
+            BlueprintName = "OFCrashOnExceptionTest"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "345069100D747ED4004B40C2"
+            BuildableName = "OFCrashOnExceptionTest"
+            BlueprintName = "OFCrashOnExceptionTest"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFDedicatedThreadSchedulerTest.xcscheme
+++ b/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFDedicatedThreadSchedulerTest.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4A4E078708AA72B10098FF0F"
+               BuildableName = "OFDedicatedThreadSchedulerTest"
+               BlueprintName = "OFDedicatedThreadSchedulerTest"
+               ReferencedContainer = "container:OmniFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A4E078708AA72B10098FF0F"
+            BuildableName = "OFDedicatedThreadSchedulerTest"
+            BlueprintName = "OFDedicatedThreadSchedulerTest"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A4E078708AA72B10098FF0F"
+            BuildableName = "OFDedicatedThreadSchedulerTest"
+            BlueprintName = "OFDedicatedThreadSchedulerTest"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFNetStateNotifier.xcscheme
+++ b/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFNetStateNotifier.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "342691D217C578F600B1372F"
+               BuildableName = "OFNetStateNotifier.app"
+               BlueprintName = "OFNetStateNotifier"
+               ReferencedContainer = "container:OmniFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "342691D217C578F600B1372F"
+            BuildableName = "OFNetStateNotifier.app"
+            BlueprintName = "OFNetStateNotifier"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "342691D217C578F600B1372F"
+            BuildableName = "OFNetStateNotifier.app"
+            BlueprintName = "OFNetStateNotifier"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFNetStateNotifierTest.xcscheme
+++ b/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFNetStateNotifierTest.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "344D562317BD47110049F9E5"
+               BuildableName = "OFNetStateNotifierTest"
+               BlueprintName = "OFNetStateNotifierTest"
+               ReferencedContainer = "container:OmniFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "344D562317BD47110049F9E5"
+            BuildableName = "OFNetStateNotifierTest"
+            BlueprintName = "OFNetStateNotifierTest"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "344D562317BD47110049F9E5"
+            BuildableName = "OFNetStateNotifierTest"
+            BlueprintName = "OFNetStateNotifierTest"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFRandomRepeatTest.xcscheme
+++ b/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFRandomRepeatTest.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "343B36331034F68F0006290A"
+               BuildableName = "OFRandomRepeatTest"
+               BlueprintName = "OFRandomRepeatTest"
+               ReferencedContainer = "container:OmniFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "343B36331034F68F0006290A"
+            BuildableName = "OFRandomRepeatTest"
+            BlueprintName = "OFRandomRepeatTest"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "343B36331034F68F0006290A"
+            BuildableName = "OFRandomRepeatTest"
+            BlueprintName = "OFRandomRepeatTest"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFXMLIdHash.xcscheme
+++ b/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OFXMLIdHash.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "34B2F63A17188539000E45DF"
+               BuildableName = "OFXMLIdHash"
+               BlueprintName = "OFXMLIdHash"
+               ReferencedContainer = "container:OmniFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "34B2F63A17188539000E45DF"
+            BuildableName = "OFXMLIdHash"
+            BlueprintName = "OFXMLIdHash"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "34B2F63A17188539000E45DF"
+            BuildableName = "OFXMLIdHash"
+            BlueprintName = "OFXMLIdHash"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OmniFoundation-iOS.xcscheme
+++ b/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OmniFoundation-iOS.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "34F16B19194F6C3200AD9C4D"
+               BuildableName = "OmniFoundation.framework"
+               BlueprintName = "OmniFoundation-iOS"
+               ReferencedContainer = "container:OmniFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "34F16B23194F6C3200AD9C4D"
+               BuildableName = "OFUnitTests.xctest"
+               BlueprintName = "OFUnitTests-iOS"
+               ReferencedContainer = "container:OmniFoundation.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "34F16B19194F6C3200AD9C4D"
+            BuildableName = "OmniFoundation.framework"
+            BlueprintName = "OmniFoundation-iOS"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OmniFoundation-server.xcscheme
+++ b/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OmniFoundation-server.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "34A061221EC110A60099028D"
+               BuildableName = "OmniFoundation.framework"
+               BlueprintName = "OmniFoundation-server"
+               ReferencedContainer = "container:OmniFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "34A061221EC110A60099028D"
+            BuildableName = "OmniFoundation.framework"
+            BlueprintName = "OmniFoundation-server"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OmniFoundation.xcscheme
+++ b/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/OmniFoundation.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4A4E05FE08AA72B10098FF0F"
+               BuildableName = "OmniFoundation.framework"
+               BlueprintName = "OmniFoundation"
+               ReferencedContainer = "container:OmniFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4A4E07A808AA72B10098FF0F"
+               BuildableName = "OFUnitTests.xctest"
+               BlueprintName = "OFUnitTests"
+               ReferencedContainer = "container:OmniFoundation.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A4E05FE08AA72B10098FF0F"
+            BuildableName = "OmniFoundation.framework"
+            BlueprintName = "OmniFoundation"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
+++ b/Frameworks/OmniFoundation/OmniFoundation.xcodeproj/xcshareddata/xcschemes/Tests.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4A4E075408AA72B10098FF0F"
+               BuildableName = "Tests"
+               BlueprintName = "Tests"
+               ReferencedContainer = "container:OmniFoundation.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4A4E075408AA72B10098FF0F"
+            BuildableName = "Tests"
+            BlueprintName = "Tests"
+            ReferencedContainer = "container:OmniFoundation.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniQuartz/CIImage-OQExtensions.m
+++ b/Frameworks/OmniQuartz/CIImage-OQExtensions.m
@@ -8,6 +8,7 @@
 #import <OmniQuartz/CIImage-OQExtensions.h>
 
 #import <OmniFoundation/NSNumber-OFExtensions-CGTypes.h>
+#import <CoreImage/CIFilter.h>
 
 RCS_ID("$Id$");
 

--- a/Frameworks/OmniQuartz/OmniQuartz.xcodeproj/xcshareddata/xcschemes/OmniQuartz-iOS.xcscheme
+++ b/Frameworks/OmniQuartz/OmniQuartz.xcodeproj/xcshareddata/xcschemes/OmniQuartz-iOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "34218E4919C23ECE00899C9A"
+               BuildableName = "OmniQuartz.framework"
+               BlueprintName = "OmniQuartz-iOS"
+               ReferencedContainer = "container:OmniQuartz.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "34218E4919C23ECE00899C9A"
+            BuildableName = "OmniQuartz.framework"
+            BlueprintName = "OmniQuartz-iOS"
+            ReferencedContainer = "container:OmniQuartz.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Frameworks/OmniQuartz/OmniQuartz.xcodeproj/xcshareddata/xcschemes/OmniQuartz.xcscheme
+++ b/Frameworks/OmniQuartz/OmniQuartz.xcodeproj/xcshareddata/xcschemes/OmniQuartz.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8DC2EF4F0486A6940098B216"
+               BuildableName = "OmniQuartz.framework"
+               BlueprintName = "OmniQuartz"
+               ReferencedContainer = "container:OmniQuartz.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DC2EF4F0486A6940098B216"
+            BuildableName = "OmniQuartz.framework"
+            BlueprintName = "OmniQuartz"
+            ReferencedContainer = "container:OmniQuartz.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Tools/FixStringsFile/FixStringsFile.xcodeproj/project.pbxproj
+++ b/Tools/FixStringsFile/FixStringsFile.xcodeproj/project.pbxproj
@@ -182,8 +182,9 @@
 				LastUpgradeCheck = 1320;
 				TargetAttributes = {
 					8DD76F740486A8DE00D96B5E = {
-						DevelopmentTeam = 34YW5XSRB7;
+						DevelopmentTeam = JVS5Q57ZPX;
 						LastSwiftMigration = "";
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
@@ -229,7 +230,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "./Tests/RunTests\n";
+			shellScript = "# ./Tests/RunTests\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -251,8 +252,11 @@
 			baseConfigurationReference = 34C4D6B208C7AB280072D2D6 /* Omni-Tool-Debug.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = JVS5Q57ZPX;
 				PRODUCT_NAME = FixStringsFile;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Debug;
 		};
@@ -261,8 +265,11 @@
 			baseConfigurationReference = 34C4D6B308C7AB280072D2D6 /* Omni-Tool-Release.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
-				CODE_SIGN_IDENTITY = "";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = JVS5Q57ZPX;
 				PRODUCT_NAME = FixStringsFile;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
 			name = Release;
 		};

--- a/Tools/FixStringsFile/FixStringsFile.xcodeproj/xcshareddata/xcschemes/FixStringsFile.xcscheme
+++ b/Tools/FixStringsFile/FixStringsFile.xcodeproj/xcshareddata/xcschemes/FixStringsFile.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1530"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+               BuildableName = "FixStringsFile"
+               BlueprintName = "FixStringsFile"
+               ReferencedContainer = "container:FixStringsFile.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      viewDebuggingEnabled = "No">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+            BuildableName = "FixStringsFile"
+            BlueprintName = "FixStringsFile"
+            ReferencedContainer = "container:FixStringsFile.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8DD76F740486A8DE00D96B5E"
+            BuildableName = "FixStringsFile"
+            BlueprintName = "FixStringsFile"
+            ReferencedContainer = "container:FixStringsFile.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
With warnings-as-errors enabled, these two files contain unused variables which computed but never used. This PR allows the frameworks to compile correctly on Xcode 14 / macOS 12.6.