### PR TITLE
Fix CoreGraphics imports for modern Xcode

### DIFF
--- a/Frameworks/OmniFoundation/DataStructures.subproj/OFExtent.h
+++ b/Frameworks/OmniFoundation/DataStructures.subproj/OFExtent.h
@@ -6,11 +6,10 @@
 // <http://www.omnigroup.com/developer/sourcecode/sourcelicense/>.
 
 #import <tgmath.h>
+#import <CoreGraphics/CGGeometry.h>
 
 #if !defined(TARGET_OS_IPHONE) || !TARGET_OS_IPHONE
 #import <Foundation/NSGeometry.h>
-#else
-#import <CoreGraphics/CGGeometry.h>
 #endif
 
 #import <OmniBase/assertions.h>

--- a/Frameworks/OmniFoundation/OFGeometry.h
+++ b/Frameworks/OmniFoundation/OFGeometry.h
@@ -6,8 +6,9 @@
 // <http://www.omnigroup.com/developer/sourcecode/sourcelicense/>.
 
 #import <Availability.h>
-#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
 #import <CoreGraphics/CGGeometry.h>
+
+#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE
 #import <UIKit/UIGeometry.h>
 #else
 #import <Foundation/NSGeometry.h>
@@ -131,4 +132,3 @@ static inline BOOL OFFloatEqualToFloatWithAccuracy(CGFloat f1, CGFloat f2, CGFlo
 extern CGRect OFCenteredIntegralRectInRect(CGRect enclosingRect, CGSize toCenter);
 extern CGRect OFLargestCenteredIntegralRectInRectWithAspectRatioAsSize(CGRect enclosingRect, CGSize toCenter);
 extern CGRect OFCenterAndFitIntegralRectInRectWithSameAspectRatioAsSize(CGRect enclosingRect, CGSize toCenter);
-


### PR DESCRIPTION
## Summary

This updates two OmniFoundation headers to import `CoreGraphics/CGGeometry.h` directly before using CoreGraphics geometry types.

`OFExtent.h` and `OFGeometry.h` use types such as `CGFloat`, `CGRect`, and `CGSize`. On modern Xcode/macOS SDK combinations, those types are not reliably available through the existing macOS-side `Foundation/NSGeometry.h` import alone.

Making the CoreGraphics import explicit avoids relying on an indirect SDK include relationship.

## Changes

- Imports `CoreGraphics/CGGeometry.h` once at the top of `OFExtent.h`.
- Imports `CoreGraphics/CGGeometry.h` once at the top of `OFGeometry.h`.
- Leaves the existing platform-specific `Foundation/NSGeometry.h` and `UIKit/UIGeometry.h` imports in place.

## Verification

Verified locally with Xcode 26.5:

```sh
xcodebuild -version
# Xcode 26.5
# Build version 17F42